### PR TITLE
Fixes nullability

### DIFF
--- a/livedata-ktx/src/test/java/me/henrytao/livedataktx/LiveDataTest.kt
+++ b/livedata-ktx/src/test/java/me/henrytao/livedataktx/LiveDataTest.kt
@@ -127,9 +127,9 @@ class LiveDataTest : LifecycleOwner {
 
     @Test
     fun nonNull() {
-        val liveData: MutableLiveData<Boolean> = MutableLiveData()
-        val actuals: MutableList<Boolean> = mutableListOf()
-        val observer: (t: Boolean) -> Unit = { actuals.add(it) }
+        val liveData: MutableLiveData<Boolean?> = MutableLiveData()
+        val actuals: MutableList<Boolean?> = mutableListOf()
+        val observer: (t: Boolean?) -> Unit = { actuals.add(it) }
         liveData
                 .nonNull()
                 .observe(this, observer)


### PR DESCRIPTION
These changes fixes the nullability when transforming `LiveData`'s.

see my ticket: https://github.com/henrytao-me/livedata-ktx/issues/3

This fixes the following scenario:
```Kotlin
val liveData = MutableLiveData<Int>
// val mapped = liveData.map { it?.let{ it.toString() } }  <-- this wouldn't be needed anymore
val mapped = liveData.map { it.toString() }
```