### PR TITLE
Add the combineWith operator

### DIFF
--- a/livedata-ktx/src/test/java/com/shopify/livedataktx/LiveDataTest.kt
+++ b/livedata-ktx/src/test/java/com/shopify/livedataktx/LiveDataTest.kt
@@ -216,4 +216,23 @@ class LiveDataTest : LifecycleOwner {
         assertEquals(expecteds1, actuals1)
         assertEquals(expecteds2, actuals2)
     }
+
+    @Test
+    fun combineWith() {
+        val firstSource = MutableLiveData<Int>()
+        val secondSource = MutableLiveData<String>()
+        val actual = mutableListOf<Long?>()
+        val observer: (t: Long?) -> Unit = { actual.add(it) }
+
+        val expectedValue: Long = 3
+
+        firstSource.value = 1
+        secondSource.value = "2"
+
+        firstSource
+            .combineWith(secondSource) {i: Int?, s: String? -> (i!!+s!!.toInt()).toLong() }
+            .observe(this, observer)
+
+        assertEquals(expectedValue, actual.first())
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/Shopify/livedata-ktx/issues/6

Creates a new operator, `combineWith`, that behaves similarly to Rx's [combineLatest](http://reactivex.io/documentation/operators/combinelatest.html).

Essentially, we create a new `MediatorLiveData` with two sources and a transformation function, which gets applied to the source's emitted value. 

Note that everything is nullable, since it may make sense for the user to supply a transformation that works in these cases (for instance, return a default value in case one of the sources is null).