### PR TITLE
Use inline and crossinline for performance and reducing the number of methods

### DIFF
--- a/livedata-ktx/src/main/java/com/shopify/livedataktx/LiveData.kt
+++ b/livedata-ktx/src/main/java/com/shopify/livedataktx/LiveData.kt
@@ -162,28 +162,28 @@ fun <T> LiveData<T>.nonNull(): SupportMediatorLiveData<T> = createMediator(this,
 /**
  * observers
  */
-fun <T> LiveData<T>.observe(owner: LifecycleOwner, observer: (t: T?) -> Unit): Removable {
-    val removable: RemovableImpl<T> = RemovableImpl(this, Observer { observer(it) })
+inline fun <T> LiveData<T>.observe(owner: LifecycleOwner, crossinline observer: (t: T?) -> Unit): Removable<T> {
+    val removable: Removable<T> = Removable(this, Observer { observer(it) })
     observe(owner, removable.observer)
     return removable
 }
 
-fun <T> LiveData<T>.observe(observer: (t: T?) -> Unit): Removable {
-    val removable: RemovableImpl<T> = RemovableImpl(this, Observer { observer(it) })
+inline fun <T> LiveData<T>.observe(crossinline observer: (t: T?) -> Unit): Removable<T> {
+    val removable: Removable<T> = Removable(this, Observer { observer(it) })
     observeForever(removable.observer)
     return removable
 }
 
 @Suppress("DEPRECATION")
-fun <T> SupportMediatorLiveData<T>.observe(owner: LifecycleOwner, observer: (t: T) -> Unit): Removable {
-    val removable: RemovableImpl<T> = RemovableImpl(this, Observer { it?.let(observer) })
+inline fun <T> SupportMediatorLiveData<T>.observe(owner: LifecycleOwner, crossinline observer: (t: T) -> Unit): Removable<T> {
+    val removable: Removable<T> = Removable(this, Observer { it?.let(observer) })
     observe(owner, removable.observer)
     return removable
 }
 
 @Suppress("DEPRECATION")
-fun <T> SupportMediatorLiveData<T>.observe(observer: (t: T) -> Unit): Removable {
-    val removable: RemovableImpl<T> = RemovableImpl(this, Observer { it?.let { observer(it) } })
+inline fun <T> SupportMediatorLiveData<T>.observe(crossinline observer: (t: T) -> Unit): Removable<T> {
+    val removable: Removable<T> = Removable(this, Observer { it?.let { observer(it) } })
     observeForever(removable.observer)
     return removable
 }
@@ -229,9 +229,3 @@ private fun <FIRST, SECOND, OUT> createCombinedMediator(firstSource: LiveData<FI
     }
 }
 
-private class RemovableImpl<T>(private val liveData: LiveData<T>, val observer: Observer<T>) : Removable {
-
-    override fun removeObserver() {
-        liveData.removeObserver(observer)
-    }
-}

--- a/livedata-ktx/src/main/java/com/shopify/livedataktx/Removable.kt
+++ b/livedata-ktx/src/main/java/com/shopify/livedataktx/Removable.kt
@@ -24,7 +24,14 @@
 
 package com.shopify.livedataktx
 
-interface Removable {
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.Observer
 
-    fun removeObserver()
+class Removable<T>(
+        private val liveData: LiveData<T>,
+        val observer: Observer<T>
+) {
+    fun removeObserver() {
+        liveData.removeObserver(observer)
+    }
 }

--- a/livedata-ktx/src/test/java/com/shopify/livedataktx/LiveDataTest.kt
+++ b/livedata-ktx/src/test/java/com/shopify/livedataktx/LiveDataTest.kt
@@ -253,4 +253,21 @@ class LiveDataTest : LifecycleOwner {
 
         assertEquals(mutableListOf(3, 1, 3, 1, 3, 1, 3), actuals)
     }
+
+    @Test
+    fun removeObserver(){
+        val liveData: MutableLiveData<Boolean> = MutableLiveData()
+        val actuals: MutableList<Boolean?> = mutableListOf()
+        val observer: (t: Boolean?) -> Unit = { actuals.add(it) }
+        val removable = liveData
+                .observe(this, observer)
+
+        liveData.value = true
+        liveData.value = false
+        removable.removeObserver()
+        liveData.value = true
+
+        val expecteds = mutableListOf(true, false)
+        assertEquals(expecteds, actuals)
+    }
 }


### PR DESCRIPTION
We can use inline function for performance and reducing the number of methods.
https://kotlinlang.org/docs/reference/inline-functions.html
Is there a reason not to use it?
