### PR TITLE
Add hotfix for 0.2.x regarding reattach

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Shopify" />
+  </state>
+</component>

--- a/livedata-ktx/src/main/java/com/shopify/livedataktx/SupportMediatorLiveData.kt
+++ b/livedata-ktx/src/main/java/com/shopify/livedataktx/SupportMediatorLiveData.kt
@@ -28,7 +28,38 @@ import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.Observer
 
-open class SupportMediatorLiveData<T>(internal val isSingle: Boolean = false, private val versionProvider: (() -> Int)? = null) : MediatorLiveData<T>() {
+private typealias ObserverWrappers<T> = MutableList<Pair<Observer<T>, Observer<T>>>
+
+private fun <T> ObserverWrappers<T>.get(observer: Observer<T>): Observer<T>? =
+    indexOfFirst { it.first == observer }
+        .takeUnless { it < 0 }
+        ?.let { this[it].second }
+
+private fun <T> ObserverWrappers<T>.getOrElse(
+    observer: Observer<T>,
+    wrapper: Observer<T>
+): Observer<T> = get(observer) ?: wrapper
+
+private fun <T> ObserverWrappers<T>.putIfAbsent(observer: Observer<T>, wrapper: Observer<T>) {
+    val index = indexOfFirst { it.first == observer }
+    if (index < 0) {
+        add(Pair(observer, wrapper))
+    }
+}
+
+private fun <T> ObserverWrappers<T>.removeIfPresent(observer: Observer<T>) {
+    val index = indexOfFirst { it.first == observer }
+    if (index >= 0) {
+        removeAt(index)
+    }
+}
+
+open class SupportMediatorLiveData<T>(
+    internal val isSingle: Boolean = false,
+    private val versionProvider: (() -> Int)? = null
+) : MediatorLiveData<T>() {
+
+    private val observerWrappers: ObserverWrappers<T> = mutableListOf()
 
     private var _version = 0
     internal val version: Int get() = versionProvider?.let { it() } ?: _version
@@ -36,20 +67,34 @@ open class SupportMediatorLiveData<T>(internal val isSingle: Boolean = false, pr
     @Deprecated("Use observe extension")
     override fun observe(owner: LifecycleOwner, observer: Observer<T>) {
         val observerVersion = version
-        super.observe(owner, Observer {
+        val wrapper = observerWrappers.getOrElse(observer, Observer {
             if (!isSingle || observerVersion < version) {
                 observer.onChanged(it)
             }
         })
+        observerWrappers.putIfAbsent(observer, wrapper)
+        super.observe(owner, wrapper)
     }
 
     @Deprecated("Use observe extension without LifecycleOwner")
     override fun observeForever(observer: Observer<T>) {
-        super.observeForever(observer)
+        val observerVersion = version
+        val wrapper = observerWrappers.getOrElse(observer, Observer {
+            if (!isSingle || observerVersion < version) {
+                observer.onChanged(it)
+            }
+        })
+        observerWrappers.putIfAbsent(observer, wrapper)
+        super.observeForever(wrapper)
     }
 
     override fun setValue(value: T?) {
         _version++
         super.setValue(value)
+    }
+
+    override fun removeObserver(observer: Observer<T>) {
+        observerWrappers.get(observer)?.let { super.removeObserver(it) }
+        observerWrappers.removeIfPresent(observer)
     }
 }

--- a/livedata-ktx/src/main/java/com/shopify/livedataktx/SupportMediatorLiveData.kt
+++ b/livedata-ktx/src/main/java/com/shopify/livedataktx/SupportMediatorLiveData.kt
@@ -28,64 +28,24 @@ import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.Observer
 
-private typealias ObserverWrappers<T> = MutableList<Pair<Observer<T>, Observer<T>>>
-
-private fun <T> ObserverWrappers<T>.get(observer: Observer<T>): Observer<T>? =
-    indexOfFirst { it.first == observer }
-        .takeUnless { it < 0 }
-        ?.let { this[it].second }
-
-private fun <T> ObserverWrappers<T>.getOrElse(
-    observer: Observer<T>,
-    wrapper: Observer<T>
-): Observer<T> = get(observer) ?: wrapper
-
-private fun <T> ObserverWrappers<T>.putIfAbsent(observer: Observer<T>, wrapper: Observer<T>) {
-    val index = indexOfFirst { it.first == observer }
-    if (index < 0) {
-        add(Pair(observer, wrapper))
-    }
-}
-
-private fun <T> ObserverWrappers<T>.removeIfPresent(observer: Observer<T>) {
-    val index = indexOfFirst { it.first == observer }
-    if (index >= 0) {
-        removeAt(index)
-    }
-}
-
 open class SupportMediatorLiveData<T>(
     internal val isSingle: Boolean = false,
     private val versionProvider: (() -> Int)? = null
 ) : MediatorLiveData<T>() {
 
-    private val observerWrappers: ObserverWrappers<T> = mutableListOf()
+    private val observerWrappers = mutableMapOf<Observer<T>, Observer<T>>();
 
     private var _version = 0
     internal val version: Int get() = versionProvider?.let { it() } ?: _version
 
     @Deprecated("Use observe extension")
     override fun observe(owner: LifecycleOwner, observer: Observer<T>) {
-        val observerVersion = version
-        val wrapper = observerWrappers.getOrElse(observer, Observer {
-            if (!isSingle || observerVersion < version) {
-                observer.onChanged(it)
-            }
-        })
-        observerWrappers.putIfAbsent(observer, wrapper)
-        super.observe(owner, wrapper)
+        super.observe(owner, getWrapperObserver(observer))
     }
 
     @Deprecated("Use observe extension without LifecycleOwner")
     override fun observeForever(observer: Observer<T>) {
-        val observerVersion = version
-        val wrapper = observerWrappers.getOrElse(observer, Observer {
-            if (!isSingle || observerVersion < version) {
-                observer.onChanged(it)
-            }
-        })
-        observerWrappers.putIfAbsent(observer, wrapper)
-        super.observeForever(wrapper)
+        super.observeForever(getWrapperObserver(observer))
     }
 
     override fun setValue(value: T?) {
@@ -94,7 +54,20 @@ open class SupportMediatorLiveData<T>(
     }
 
     override fun removeObserver(observer: Observer<T>) {
-        observerWrappers.get(observer)?.let { super.removeObserver(it) }
-        observerWrappers.removeIfPresent(observer)
+        observerWrappers[observer]?.also {
+            super.removeObserver(it)
+            observerWrappers.remove(observer)
+        }
+    }
+
+    private fun getWrapperObserver(observer: Observer<T>): Observer<T> {
+        val observerVersion = version
+        val wrapper = observerWrappers[observer] ?: Observer {
+            if (!isSingle || observerVersion < version) {
+                observer.onChanged(it)
+            }
+        }
+        observerWrappers[observer] = wrapper
+        return wrapper
     }
 }

--- a/livedata-ktx/src/test/java/com/shopify/livedataktx/LiveDataTest.kt
+++ b/livedata-ktx/src/test/java/com/shopify/livedataktx/LiveDataTest.kt
@@ -218,6 +218,21 @@ class LiveDataTest : LifecycleOwner {
     }
 
     @Test
+    fun single_observeForever() {
+        val liveData: MutableLiveData<Int> = SingleLiveData()
+        val actuals: MutableList<Int?> = mutableListOf()
+        val observer: (t: Int?) -> Unit = { actuals.add(it) }
+
+        liveData.value = 1
+        liveData.observeForever(observer)
+        liveData.value = 2
+        liveData.value = 3
+
+        val expecteds = mutableListOf(2, 3)
+        assertEquals(expecteds, actuals)
+    }
+
+    @Test
     fun combineWith() {
         val firstSource = MutableLiveData<Int>()
         val secondSource = MutableLiveData<String>()
@@ -252,5 +267,71 @@ class LiveDataTest : LifecycleOwner {
                 .observe(this, observer)
 
         assertEquals(mutableListOf(3, 1, 3, 1, 3, 1, 3), actuals)
+    }
+
+    @Test
+    fun reattach() {
+        val liveData: MutableLiveData<Int> = MutableLiveData()
+        val actuals: MutableList<Int?> = mutableListOf()
+        val observer: (t: Int?) -> Unit = { actuals.add(it) }
+        val removable = liveData.observe(this, observer)
+
+        liveData.value = 1
+        liveData.value = 2
+        removable.removeObserver()
+        assertEquals(listOf(1, 2), actuals)
+        actuals.clear()
+
+        liveData.value = 3
+        liveData.value = 4
+
+        liveData.observe(this, observer)
+        liveData.value = 5
+        liveData.value = 6
+        assertEquals(listOf(4, 5, 6), actuals)
+    }
+
+    @Test
+    fun reattach_singleLiveData() {
+        val liveData: MutableLiveData<Int> = SingleLiveData()
+        val actuals: MutableList<Int?> = mutableListOf()
+        val observer: (t: Int?) -> Unit = { actuals.add(it) }
+        val removable = liveData.observe(this, observer)
+
+        liveData.value = 1
+        liveData.value = 2
+        removable.removeObserver()
+        assertEquals(listOf(1, 2), actuals)
+        actuals.clear()
+
+        liveData.value = 3
+        liveData.value = 4
+
+        liveData.observe(this, observer)
+        liveData.value = 5
+        liveData.value = 6
+        assertEquals(listOf(5, 6), actuals)
+    }
+
+    @Test
+    fun reattach_singleLiveData_observeForever() {
+        val liveData: MutableLiveData<Int> = SingleLiveData()
+        val actuals: MutableList<Int?> = mutableListOf()
+        val observer: (t: Int?) -> Unit = { actuals.add(it) }
+        val removable = liveData.observe(observer)
+
+        liveData.value = 1
+        liveData.value = 2
+        removable.removeObserver()
+        assertEquals(listOf(1, 2), actuals)
+        actuals.clear()
+
+        liveData.value = 3
+        liveData.value = 4
+
+        liveData.observe( observer)
+        liveData.value = 5
+        liveData.value = 6
+        assertEquals(listOf(5, 6), actuals)
     }
 }


### PR DESCRIPTION
This PR adds hotfix for version 0.2.x regarding reattach. `removeObserver` doesn't work properly because of a wrapper in `SupportMediatorLiveData.kt`.